### PR TITLE
Added negative bases to odd-numbered roots

### DIFF
--- a/lib/src/defs.dart
+++ b/lib/src/defs.dart
@@ -3,7 +3,7 @@ part of function_tree;
 /// A mapping of string representations to two-parameter functions.
 final Map<String, num Function(num, num)> _twoParameterFunctionMap = {
   'log': (num b, num x) => log(x) / log(b),
-  'nrt': (num n, num x) => pow(x, 1 / n),
+  'nrt': (num n, num x) => (x.isNegative ? -1:1)* pow(x.abs(), 1 / n),
   'pow': (num x, num p) => pow(x, p)
 };
 

--- a/lib/src/defs.dart
+++ b/lib/src/defs.dart
@@ -3,7 +3,7 @@ part of function_tree;
 /// A mapping of string representations to two-parameter functions.
 final Map<String, num Function(num, num)> _twoParameterFunctionMap = {
   'log': (num b, num x) => log(x) / log(b),
-  'nrt': (num n, num x) => (x.isNegative ? -1:1)* pow(x.abs(), 1 / n),
+  'nrt': (num n, num x) => (x.isNegative && n.toInt().isOdd ? -1:1)* pow(n.toInt().isOdd ? x.abs() : x, 1 / n),
   'pow': (num x, num p) => pow(x, p)
 };
 

--- a/test/two-parameter-functions.dart
+++ b/test/two-parameter-functions.dart
@@ -12,4 +12,7 @@ void main() {
 
   final h = 'nrt(3, 27)'.interpret();
   print(h);
+
+  final i = 'nrt(3, -3)'.interpret();
+  print(i);
 }


### PR DESCRIPTION
In mathematics there is a root of a negative number if the index of the root is odd, but this library (actually dart's fault) returned NaN, so I applied a fix.

I did this fix very quickly, so feel free to modify it if it doesn't meet your programming criteria