### PR TITLE
Fix regression of missing backslash in \frac, \cdot and \bmod

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.9.2
 
-- Bring back missing backslashes in the TeX representations \cdot and \bmod.
+- Bring back missing backslashes in the TeX representations \frac, \cdot and \bmod.
 
 ## 0.9.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change log
 
+## 0.9.2
+
+- Bring back missing backslashes in the TeX representations \cdot and \bmod.
+
 ## 0.9.1
 
 - Added the ability to create symbolic derivatives from single variable functions where they are well defined. Early versions had numeric differentiation (and integration), but these were removed in later versions as not being part of the focused use case. (I'm not sure whether symbolic derivatives will stay either — they're still experimental.) These can be accessed through the methods `SingleVariableFunction.derivative` and `MultiVariableFunction.partial`. The resulting trees are often unnecessarily large for now; tree pruning to come if the trees are to stay!

--- a/lib/src/forks.dart
+++ b/lib/src/forks.dart
@@ -118,7 +118,7 @@ class QuotientFork extends Fork {
           right: right,
           label: "Quotient",
           generateTeX: (left, right) =>
-              "\frac{${left.toTeX()}}{${right.toTeX()}}",
+              "\\frac{${left.toTeX()}}{${right.toTeX()}}",
           generateString: (left, right) => "($left) / ($right)",
           definition: (a, b) => a / b,
         );

--- a/lib/src/forks.dart
+++ b/lib/src/forks.dart
@@ -98,7 +98,7 @@ class ProductFork extends Fork {
           right: right,
           label: "Product",
           generateTeX: (left, right) =>
-              "${left.toTeX()} \cdot ${right.toTeX()}",
+              "${left.toTeX()} \\cdot ${right.toTeX()}",
           generateString: (left, right) => "$left * $right",
           definition: (a, b) => a * b,
         );
@@ -140,7 +140,7 @@ class ModulusFork extends Fork {
           right: right,
           label: "Modulus",
           generateTeX: (left, right) =>
-              "${left.toTeX()} \bmod ${right.toTeX()}",
+              "${left.toTeX()} \\bmod ${right.toTeX()}",
           generateString: (left, right) => "$left % $right",
           definition: (a, b) => a % b,
         );

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: function_tree
 description: A simple library for parsing strings into callable function-trees.
-version: 0.9.1
+version: 0.9.2
 homepage: https://github.com/ram6ler/function-tree
 
 environment:


### PR DESCRIPTION
`0.9.0` introduced a regression in `generateTeX` of the forks `ProductFork`, `QuotientFork` and `ModulusFork`, as backslashes were not escaped.